### PR TITLE
Fix server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@cocal/google-calendar-mcp",
-  "version": "1.3.0",
+  "name": "@xalia/google-calendar-mcp",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cocal/google-calendar-mcp",
-      "version": "1.3.0",
+      "name": "@xalia/google-calendar-mcp",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/local-auth": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sudomcp/google-calendar-mcp",
+  "name": "@xalia/google-calendar-mcp",
   "version": "1.4.0",
   "description": "Google Calendar MCP Server",
   "type": "module",
@@ -23,13 +23,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nspady/google-calendar-mcp.git"
+    "url": "git+https://github.com/General-Intelligence-Labs/google-calendar-mcp.git"
   },
   "bugs": {
-    "url": "https://github.com/nspady/google-calendar-mcp/issues"
+    "url": "https://github.com/General-Intelligence-Labs/google-calendar-mcp/issues"
   },
-  "homepage": "https://github.com/nspady/google-calendar-mcp#readme",
-  "author": "nspady",
+  "homepage": "https://github.com/General-Intelligence-Labs/google-calendar-mcp#readme",
+  "author": "nspady, vliew, GhostOfGauss",
   "license": "MIT",
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -71,6 +71,9 @@ export async function initializeOAuth2ClientFromHost(): Promise<OAuth2Client> {
   }
   // The client ID/secret/redirectUri are not needed for access token only, but GoogleAuthLibrary requires some values.
   const client = new OAuth2Client();
-  client.setCredentials({ access_token: accessToken });
+  client.setCredentials({
+    access_token: accessToken,
+    scope: "https://www.googleapis.com/auth/calendar",
+  });
   return client;
 }

--- a/src/handlers/callTool.ts
+++ b/src/handlers/callTool.ts
@@ -9,6 +9,7 @@ import { CreateEventHandler } from "./core/CreateEventHandler.js";
 import { UpdateEventHandler } from "./core/UpdateEventHandler.js";
 import { DeleteEventHandler } from "./core/DeleteEventHandler.js";
 import { FreeBusyEventHandler } from "./core/FreeBusyEventHandler.js";
+import { GetDateTimeHandler } from "./core/GetDateTimeHandler.js";
 
 /**
  * Handles incoming tool calls, validates arguments, calls the appropriate service,
@@ -40,6 +41,7 @@ const handlerMap: Record<string, BaseToolHandler> = {
     "update-event": new UpdateEventHandler(),
     "delete-event": new DeleteEventHandler(),
     "get-freebusy": new FreeBusyEventHandler(),
+    "get-date-time": new GetDateTimeHandler(),
 };
 
 function getHandler(toolName: string): BaseToolHandler {

--- a/src/handlers/core/GetDateTimeHandler.ts
+++ b/src/handlers/core/GetDateTimeHandler.ts
@@ -1,0 +1,13 @@
+import { BaseToolHandler } from "./BaseToolHandler.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export class GetDateTimeHandler extends BaseToolHandler {
+    async runTool(_:any): Promise<CallToolResult> {
+        return {
+            content: [{
+                type: "text",
+                text: new Date().toISOString()
+            }],
+        };
+    }
+}

--- a/src/handlers/listTools.ts
+++ b/src/handlers/listTools.ts
@@ -367,6 +367,15 @@ export function getToolDefinitions() {
           },
           required: ["timeMin", "timeMax", "items"],
         },
+      },
+      {
+        name: "get-date-time",
+        description: "Get the current date and time (UTC). Always call this first.",
+        inputSchema: {
+          type: "object",
+          properties: {}, // No arguments needed
+          required: [],
+        },
       }
     ],
   };

--- a/src/handlers/listTools.ts
+++ b/src/handlers/listTools.ts
@@ -265,7 +265,7 @@ export function getToolDefinitions() {
               type: "string",
               enum: ["single", "all", "future"],
               default: "all",
-              description: "Scope of modification for recurring events: 'single' (one instance), 'all' (entire series), 'future' (this and future instances). Defaults to 'all' for backward compatibility."
+              description: "Scope of modification for recurring events: 'single' (one instance, requires originalStartTime), 'all' (entire series), 'future' (this and future instances, requires futureStartDate). Defaults to 'all' for backward compatibility."
             },
             originalStartTime: {
               type: "string",
@@ -279,28 +279,31 @@ export function getToolDefinitions() {
             }
           },
           required: ["calendarId", "eventId", "timeZone"], // timeZone is technically required for PATCH
-          allOf: [
-            {
-              if: { 
-                properties: { 
-                  modificationScope: { const: "single" } 
-                } 
-              },
-              then: { 
-                required: ["originalStartTime"] 
-              }
-            },
-            {
-              if: { 
-                properties: { 
-                  modificationScope: { const: "future" } 
-                } 
-              },
-              then: { 
-                required: ["futureStartDate"] 
-              }
-            }
-          ]
+          // NOTE: `allOf` is not part of OpenAI's JsonSchema support, see
+          // https://platform.openai.com/docs/guides/structured-outputs?context=with_parse&api-mode=chat#supported-schemas
+          // These conditions are already enforced by Zod when validating the schema.
+          // allOf: [
+          //   {
+          //     if: { 
+          //       properties: { 
+          //         modificationScope: { const: "single" } 
+          //       } 
+          //     },
+          //     then: { 
+          //       required: ["originalStartTime"] 
+          //     }
+          //   },
+          //   {
+          //     if: { 
+          //       properties: { 
+          //         modificationScope: { const: "future" } 
+          //       } 
+          //     },
+          //     then: { 
+          //       required: ["futureStartDate"] 
+          //     }
+          //   }
+          // ]
         },
       },
       {


### PR DESCRIPTION
Fixes:
- `update-event` tool schema did not adhere to OpenAI's JsonSchema support, see [here](https://platform.openai.com/docs/guides/structured-outputs?context=with_parse&api-mode=chat#supported-schemas). 
 
Removed the offending `allOf` section from the schema. This probably makes the LLM more likely to propose invalid inputs to that tool, but the existing validation will return an error (and not attempt the bad tool call). The LLM should be able to recover from that error message.

Features:
- `get-date-time` tool that the LLM can use to fetch the current date and time. Otherwise requests like "what's on my calendar today?" are carried out with the model's training cutoff date.